### PR TITLE
[FIX] 장애물과 아이템 관련 버그 수정

### DIFF
--- a/Assets/Scripts/Disturbance/Bulb.cs
+++ b/Assets/Scripts/Disturbance/Bulb.cs
@@ -15,6 +15,12 @@ public class Bulb : MonoBehaviour
     void Start()
     {
         random_image();
+
+        // 쉴드 중이면 
+        if (GameObject.Find("DisturbanceManager").GetComponent<DisturbanceManager>().isSheild)
+        {
+            gameObject.GetComponent<BoxCollider2D>().enabled = false;
+        }
     }
 
     void Awake()

--- a/Assets/Scripts/Disturbance/DisturbanceManager.cs
+++ b/Assets/Scripts/Disturbance/DisturbanceManager.cs
@@ -88,6 +88,7 @@ public class DisturbanceManager : MonoBehaviour
     public void StartShield()
     {
         // 함정 스크립트 비활성화
+        // 함정 충돌 관련 스크립트에서 관리 !! 
         isSheild = true;
 
         if (temp == null)

--- a/Assets/Scripts/Disturbance/DisturbanceManager.cs
+++ b/Assets/Scripts/Disturbance/DisturbanceManager.cs
@@ -114,6 +114,8 @@ public class DisturbanceManager : MonoBehaviour
 
     void RealEndShield()
     {
+        Debug.Log("쉴드 끝");
+
         isSheild = false;
         if (temp == null)
         {

--- a/Assets/Scripts/Disturbance/Ornament.cs
+++ b/Assets/Scripts/Disturbance/Ornament.cs
@@ -17,6 +17,12 @@ public class Ornament : MonoBehaviour
     {
         random_image();
         pos = transform.position;
+
+        // 쉴드 중이면 
+        if (GameObject.Find("DisturbanceManager").GetComponent<DisturbanceManager>().isSheild)
+        {
+            gameObject.GetComponent<BoxCollider2D>().enabled = false;
+        }
     }
     // Start is called before the first frame update
     void Awake()

--- a/Assets/Scripts/Item/ItemManager.cs
+++ b/Assets/Scripts/Item/ItemManager.cs
@@ -82,14 +82,17 @@ public class ItemManager : MonoBehaviour
 
     public void EffectGinger()
     {
-        //if(GameObject.FindWithTag("Player").GetComponent<Animator>().runtimeAnimatorController == CookieCharacter.GetComponent<Animator>().runtimeAnimatorController)
-        //{
-        //    Debug.Log("넘어감!");
-        //    return;
-        //}
         // 쉴드
         GameObject.Find("DisturbanceManager").GetComponent<DisturbanceManager>().StartShield();
         ChangePlayer(cookiePlayer);
+
+        if (IsInvoking("ShieldFalse") || IsInvoking("RealEndShield"))
+        {
+            Debug.Log("실행중이던 쉴드 멈춤");
+            CancelInvoke("ShieldFalse");
+            CancelInvoke("RealEndShield");
+        }
+        Debug.Log("다시 쉴드 시작");
         Invoke("ShieldFalse", shieldTime);
     }
 


### PR DESCRIPTION
- 진저 쿠키 효과 적용 중일 때, 또 쿠키 먹었을 경우 원래 적용이 안되었는데, 기존 효과 멈추고 새로 적용되도록 수정
- 새로 생기는 장애물에 쉴드 효과가 안 먹었었음. 진저 쿠키 효과 적용중일 때 생기는 장애물에 대해 처리